### PR TITLE
update classpath to fix java se error

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.launching.macosx.MacOSXType/Java SE 8 [1.8.0_172]">
-		<attributes>
-			<attribute name="module" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="lib" path="commons-validator-1.4.1.jar"/>
 	<classpathentry kind="lib" path="opencsv-3.1.jar"/>
 	<classpathentry kind="lib" path="commons-net-3.4.jar"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
This removes the error that you get when importing the project in Eclipse on Windows or Linux.